### PR TITLE
Adds a release plugin so we can make releases (.aar format)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.1.0'
-
+        classpath 'com.novoda:bintray-release:0.3.4'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/zettakit/build.gradle
+++ b/zettakit/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'com.novoda.bintray-release'
 
 android {
     compileSdkVersion 23
@@ -16,14 +17,27 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    lintOptions {
+        warning 'InvalidPackage' // https://github.com/FasterXML/jackson-databind/issues/1192
+    }
 }
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.3.0'
+    compile 'com.android.support:appcompat-v7:23.4.0'
     compile 'com.squareup.okhttp3:okhttp-ws:3.2.0'
     compile 'com.fasterxml.jackson.core:jackson-core:2.7.3'
     compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.3'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.7.3'
+}
+
+publish {
+    userOrg = 'zetta'
+    groupId = 'com.apigee'
+    artifactId = 'zettakit'
+    publishVersion = '0.0.1'
+    desc = 'An Android SDK for the Zetta API.'
+    website = 'https://github.com/zettaapi/zetta-sdk-android'
 }

--- a/zettakit/src/androidTest/java/com/apigee/zettakit/ApplicationTest.java
+++ b/zettakit/src/androidTest/java/com/apigee/zettakit/ApplicationTest.java
@@ -11,6 +11,7 @@ import com.apigee.zettakit.callbacks.ZIKServersCallback;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /**
  * <a href="http://d.android.com/tools/testing/testing_android.html">Testing Fundamentals</a>
@@ -19,17 +20,18 @@ public class ApplicationTest extends ApplicationTestCase<Application> {
     public ApplicationTest() {
         super(Application.class);
     }
+
     public void testGET() throws InterruptedException {
         final CountDownLatch signal = new CountDownLatch(1);
         ZIKSession.init(this.getContext());
         final ZIKSession sharedSession = ZIKSession.getSharedSession();
-        sharedSession.getRoot("http://v1-staging.iot.apigee.net/", new ZIKRootCallback() {
+        sharedSession.getRoot("http://stage.zettaapi.org", new ZIKRootCallback() {
             @Override
             public void onSuccess(@NonNull ZIKRoot root) {
                 sharedSession.getServers(root, new ZIKServersCallback() {
                     @Override
                     public void onFinished(@Nullable List<ZIKServer> servers) {
-                        if( servers != null && !servers.isEmpty() ) {
+                        if (servers != null && !servers.isEmpty()) {
                             ZIKServer server = servers.get(0);
                             sharedSession.getDevices(server, new ZIKDevicesCallback() {
                                 @Override
@@ -37,15 +39,18 @@ public class ApplicationTest extends ApplicationTestCase<Application> {
                                     signal.countDown();
                                 }
                             });
+                        } else {
+                            throw new IllegalStateException("unexpected code path for this test");
                         }
                     }
                 });
             }
+
             @Override
             public void onError(@NonNull String error) {
-                signal.countDown();
+                throw new IllegalStateException("unexpected code path for this test");
             }
         });
-        signal.await();
+        signal.await(30, TimeUnit.SECONDS);
     }
 }

--- a/zettakit/src/main/AndroidManifest.xml
+++ b/zettakit/src/main/AndroidManifest.xml
@@ -7,11 +7,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
+    <application />
 
 </manifest>

--- a/zettakit/src/main/AndroidManifest.xml
+++ b/zettakit/src/main/AndroidManifest.xml
@@ -1,12 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.apigee.zettakit">
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <application />
 
 </manifest>


### PR DESCRIPTION
can now release the app with a single command, we use this gradle plugin: https://github.com/novoda/bintray-release

We will release with the command:

`./gradlew clean build bintrayUpload -PbintrayUser=BINTRAY_USERNAME -PbintrayKey=BINTRAY_KEY -PdryRun=false`

just waiting for the bintray account to be created so that we have a key.

For now I can release it locally with the cmd:

`./gradlew clean build bintrayUpload -PbintrayUser=foo -PbintrayKey=bar -PdryRun=true`

This will put an aar locally on your machine:

![screen shot 2016-06-03 at 7 21 29 pm](https://cloud.githubusercontent.com/assets/655860/15788755/008b6d3e-29c1-11e6-891d-26319c688575.png)

Which can then be referenced in the build.gradle of https://github.com/zettaapi/zetta-starter-app-android like this:

```
allprojects {
    repositories {
        mavenLocal()
...
```

and 

```
dependencies {
    compile "com.apigee:zettakit:0.0.1"
```
