### PR TITLE
makes the topic title accessible

### DIFF
--- a/zettakit/src/androidTest/java/com/apigee/zettakit/ApplicationTest.java
+++ b/zettakit/src/androidTest/java/com/apigee/zettakit/ApplicationTest.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.os.Parcel;
 import android.support.annotation.NonNull;
 import android.test.ApplicationTestCase;
+import android.util.Log;
 
 import com.apigee.zettakit.interfaces.ZIKCallback;
 import com.apigee.zettakit.interfaces.ZIKStreamListener;
@@ -99,7 +100,8 @@ public class ApplicationTest extends ApplicationTestCase<Application> {
                                                     assertTrue(object instanceof ZIKStreamEntry);
                                                     ZIKStreamEntry streamEntry = (ZIKStreamEntry) object;
                                                     assertTrue(streamEntry.getData() instanceof Double);
-                                                    System.out.print(streamEntry.getData());
+                                                    Log.d("zik", ">" + streamEntry.getData());
+                                                    Log.d("zik", ">" + streamEntry.getTitle());
                                                     stream.close();
                                                 }
 

--- a/zettakit/src/main/java/com/apigee/zettakit/ZIKStreamEntry.java
+++ b/zettakit/src/main/java/com/apigee/zettakit/ZIKStreamEntry.java
@@ -18,6 +18,6 @@ public class ZIKStreamEntry {
     }
 
     @NonNull public String getTitle() {
-        return topic.substring(topic.lastIndexOf("/" + 1), topic.length());
+        return topic.substring(topic.lastIndexOf("/") + 1, topic.length());
     }
 }

--- a/zettakit/src/main/java/com/apigee/zettakit/ZIKStreamEntry.java
+++ b/zettakit/src/main/java/com/apigee/zettakit/ZIKStreamEntry.java
@@ -16,4 +16,8 @@ public class ZIKStreamEntry {
         this.timeStamp = timestamp;
         this.data = data;
     }
+
+    @NonNull public String getTitle() {
+        return topic.substring(topic.lastIndexOf("/" + 1), topic.length());
+    }
 }


### PR DESCRIPTION
Can now get the topic title from the `ZikStreamEntry`

When the test runs the output is:

```
06-11 09:27:23.255 12341-12366/com.apigee.zettakit.test D/zik: >31.10282272632466
06-11 09:27:23.256 12341-12366/com.apigee.zettakit.test D/zik: >temperature
```

Not sure if there is a better way to get this? Feel free to change it, this does the job for me for now.
